### PR TITLE
:sparkle: Redirect to the good page

### DIFF
--- a/src/components/TabBar.component.tsx
+++ b/src/components/TabBar.component.tsx
@@ -55,9 +55,16 @@ class TabBarComponent extends React.Component<IPropsType> {
       }
     ];
     const goToPage = (selected: string) => {
+      // find in wich page we currently are in order to redirect to this page.
+      const pathArray = this.props.location.pathname.split("/");
+      pathArray.splice(0, 3); // remove '/', 'china || international' and 'dc || di || eib || il'
+      const myCurrentSubPath = pathArray.join("/");
+
       const routeSelected = routes.filter(route => route.name === selected)[0];
-      this.props.history.push(routeSelected.path);
-      this.setState({ currentFocusedTab: routeSelected.parent });
+      this.props.history.push(routeSelected.path + "/" + myCurrentSubPath);
+      this.setState({
+        currentFocusedTab: routeSelected.parent
+      });
     };
     const { classes } = this.props;
     return (


### PR DESCRIPTION
Right now we redirect to /kpis by default when we switch from china to international in the tab bar. This pr allows to remember in which subpath we were and redirect to this subpath